### PR TITLE
Fix many of the JSHint warnings

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,0 @@
-{
-	"eqnull": true,
-	"sub": true,
-	"multistr": true
-}
-

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,6 @@
+{
+	"eqnull": true,
+	"sub": true,
+	"multistr": true
+}
+

--- a/script/engine.js
+++ b/script/engine.js
@@ -495,7 +495,7 @@
 				var diff = Math.abs(panelIndex - currentIndex);
 				slider.animate({left: -(panelIndex * 700) + 'px'}, 300 * diff);
 
-				if($SM.get('stores.wood') != undefined) {
+				if($SM.get('stores.wood') !== undefined) {
 				// FIXME Why does this work if there's an animation queue...?
 					stores.animate({right: -(panelIndex * 700) + 'px'}, 300 * diff);
 				}

--- a/script/engine.js
+++ b/script/engine.js
@@ -120,11 +120,11 @@
 					.addClass('customSelect')
 					.addClass('menuBtn')
 					.appendTo(menu);
-				var options = $('<span>')
+				var selectOptions = $('<span>')
 					.addClass('customSelectOptions')
 					.appendTo(customSelect);
 				var optionsList = $('<ul>')
-					.appendTo(options);
+					.appendTo(selectOptions);
 				$('<li>')
 					.text("language.")
 					.appendTo(optionsList);
@@ -339,7 +339,7 @@
 					}
 				}
 			});
-			Engine.autoSelect('#description textarea')
+			Engine.autoSelect('#description textarea');
 		},
 
 		import64: function(string64) {
@@ -462,7 +462,6 @@
 			var darkCss = Engine.findStylesheet('darkenLights');
 			if (darkCss == null) {
 				$('head').append('<link rel="stylesheet" href="css/dark.css" type="text/css" title="darkenLights" />');
-				Engine.turnLightsOff;
 				$('.lightsOff').text(_('lights on.'));
 			} else if (darkCss.disabled) {
 				darkCss.disabled = false;

--- a/script/events.js
+++ b/script/events.js
@@ -19,7 +19,7 @@ var Events = {
 		);
 		
 		// Build the Event Pool
-		Events.EventPool = new Array().concat(
+		Events.EventPool = [].concat(
 			Events.Global,
 			Events.Room,
 			Events.Outside
@@ -35,9 +35,7 @@ var Events = {
 	
 	options: {}, // Nothing for now
     
-	activeEvent: null,
 	activeScene: null,
-	eventPanel: null,
     
 	loadScene: function(name) {
 		Engine.log('loading scene: ' + name);
@@ -88,7 +86,7 @@ var Events = {
 		for(var k in World.Weapons) {
 			var weapon = World.Weapons[k];
 			if(typeof Path.outfit[k] == 'number' && Path.outfit[k] > 0) {
-				if(typeof weapon.damage != 'number' || weapon.damage == 0) {
+				if(typeof weapon.damage != 'number' || weapon.damage === 0) {
 					// Weapons that deal no damage don't count
 					numWeapons--;
 				} else if(weapon.cost){
@@ -104,13 +102,13 @@ var Events = {
 				Events.createAttackButton(k).appendTo(btns);
 			}
 		}
-		if(numWeapons == 0) {
+		if(numWeapons === 0) {
 			// No weapons? You can punch stuff!
 			Events.createAttackButton('fists').prependTo(btns);
 		}
 		
 		Events.createEatMeatButton().appendTo(btns);
-		if((Path.outfit['medicine'] || 0) != 0) {
+		if((Path.outfit['medicine'] || 0) !== 0) {
 			Events.createUseMedsButton().appendTo(btns);
 		}
 		
@@ -131,7 +129,7 @@ var Events = {
 			cost: { 'cured meat': 1 }
 		});
 		
-		if(Path.outfit['cured meat'] == 0) {
+		if(Path.outfit['cured meat'] === 0) {
 			Button.setDisabled(btn, true);
 		}
 		
@@ -151,7 +149,7 @@ var Events = {
 			cost: { 'medicine': 1 }
 		});
 		
-		if((Path.outfit['medicine'] || 0) == 0) {
+		if((Path.outfit['medicine'] || 0) === 0) {
 			Button.setDisabled(btn, true);
 		}
 		
@@ -203,7 +201,7 @@ var Events = {
 		if(Path.outfit['cured meat'] > 0) {
 			Path.outfit['cured meat']--;
 			World.updateSupplies();
-			if(Path.outfit['cured meat'] == 0) {
+			if(Path.outfit['cured meat'] === 0) {
 				Button.setDisabled($('#eat'), true);
 			}
 			
@@ -225,7 +223,7 @@ var Events = {
 		if(Path.outfit['medicine'] > 0) {
 			Path.outfit['medicine']--;
 			World.updateSupplies();
-			if(Path.outfit['medicine'] == 0) {
+			if(Path.outfit['medicine'] === 0) {
 				Button.setDisabled($('#meds'), true);
 			}
 			
@@ -286,7 +284,7 @@ var Events = {
 					if(!validWeapons) {
 						// enable or create the punch button
 						var fists = $('#attack_fists');
-						if(fists.length == 0) {
+						if(fists.length === 0) {
 							Events.createAttackButton('fists').prependTo('#buttons', Events.eventPanel());
 						} else {
 							Button.setDisabled(fists, false);
@@ -477,7 +475,7 @@ var Events = {
 						}).appendTo(btns));
 						
 						Events.createEatMeatButton(0).appendTo(btns);
-						if((Path.outfit['medicine'] || 0) != 0) {
+						if((Path.outfit['medicine'] || 0) !== 0) {
 							Events.createUseMedsButton(0).appendTo(btns);
 						}
 					}
@@ -542,7 +540,7 @@ var Events = {
 				var num = btn.data('numLeft');
 				num--;
 				btn.data('numLeft', num);
-				if(num == 0) {
+				if(num === 0) {
 					Button.setDisabled(btn);
 					btn.animate({'opacity':0}, 300, 'linear', function() {
 						$(this).remove();
@@ -764,7 +762,7 @@ var Events = {
 				}
 			}
 
-			if(possibleEvents.length == 0) {
+			if(possibleEvents.length === 0) {
 				Events.scheduleNextEvent(0.5);
 				return;
 			} else {

--- a/script/events/outside.js
+++ b/script/events/outside.js
@@ -216,7 +216,7 @@ Events.Outside = [
 	{ /* Soldier attack */
 		title: _('A Military Raid'),
 		isAvailable: function() {
-			return Engine.activeModule == Outside && $SM.get('game.population', true) > 0 && $SM.get('game.cityCleared');;
+			return Engine.activeModule == Outside && $SM.get('game.population', true) > 0 && $SM.get('game.cityCleared');
 		},
 		scenes: {
 			'start': {

--- a/script/events/room.js
+++ b/script/events/room.js
@@ -132,9 +132,9 @@ Events.Room = [
 				onLoad: function() {
 					var numWood = $SM.get('stores.wood', true);
 					numWood = Math.floor(numWood * 0.1);
-					if(numWood == 0) numWood = 1;
+					if(numWood === 0) numWood = 1;
 					var numScales = Math.floor(numWood / 5);
-					if(numScales == 0) numScales = 1;
+					if(numScales === 0) numScales = 1;
 					$SM.addM('stores', {'wood': -numWood, 'scales': numScales});
 				},
 				buttons: {
@@ -152,9 +152,9 @@ Events.Room = [
 				onLoad: function() {
 					var numWood = $SM.get('stores.wood', true);
 					numWood = Math.floor(numWood * 0.1);
-					if(numWood == 0) numWood = 1;
+					if(numWood === 0) numWood = 1;
 					var numTeeth = Math.floor(numWood / 5);
-					if(numTeeth == 0) numTeeth = 1;
+					if(numTeeth === 0) numTeeth = 1;
 					$SM.addM('stores', {'wood': -numWood, 'teeth': numTeeth});
 				},
 				buttons: {
@@ -172,9 +172,9 @@ Events.Room = [
 				onLoad: function() {
 					var numWood = $SM.get('stores.wood', true);
 					numWood = Math.floor(numWood * 0.1);
-					if(numWood == 0) numWood = 1;
+					if(numWood === 0) numWood = 1;
 					var numCloth = Math.floor(numWood / 5);
-					if(numCloth == 0) numCloth = 1;
+					if(numCloth === 0) numCloth = 1;
 					$SM.addM('stores', {'wood': -numWood, 'cloth': numCloth});
 				},
 				buttons: {

--- a/script/notifications.js
+++ b/script/notifications.js
@@ -33,7 +33,7 @@ var Notifications = {
 		if(module != null && Engine.activeModule != module) {
 			if(!noQueue) {
 				if(typeof this.notifyQueue[module] == 'undefined') {
-					this.notifyQueue[module] = new Array();
+					this.notifyQueue[module] = [];
 				}
 				this.notifyQueue[module].push(text);
 			}

--- a/script/outside.js
+++ b/script/outside.js
@@ -178,7 +178,7 @@ var Outside = {
 		var space = Outside.getMaxPopulation() - $SM.get('game.population');
 		if(space > 0) {
 			var num = Math.floor(Math.random()*(space/2) + space/2);
-			if(num == 0) num = 1;
+			if(num === 0) num = 1;
 			if(num == 1) {
 				Notifications.notify(null, _('a stranger arrives in the night'));
 			} else if(num < 5) {
@@ -205,9 +205,9 @@ var Outside = {
 		if(remaining < 0) {
 			var gap = -remaining;
 			for(var k in $SM.get('game.workers')) {
-				var num = $SM.get('game.workers["'+k+'"]');
-				if(num < gap) {
-					gap -= num;
+				var numWorkers = $SM.get('game.workers["'+k+'"]');
+				if(numWorkers < gap) {
+					gap -= numWorkers;
 					$SM.set('game.workers["'+k+'"]', 0);
 				} else {
 					$SM.add('game.workers["'+k+'"]', gap * -1);
@@ -228,10 +228,10 @@ var Outside = {
 
 		// If our population is 0 and we don't already have a workers view,
 		// there's nothing to do here.
-		if(!workers.length && $SM.get('game.population') == 0) return;
+		if(!workers.length && $SM.get('game.population') === 0) return;
 
 		var needsAppend = false;
-		if(workers.length == 0) {
+		if(workers.length === 0) {
 			needsAppend = true;
 			workers = $('<div>').attr('id', 'workers').css('opacity', 0);
 		}
@@ -242,7 +242,7 @@ var Outside = {
 		for(var k in $SM.get('game.workers')) {
 			var workerCount = $SM.get('game.workers["'+k+'"]');
 			var row = $('div#workers_row_' + k.replace(' ', '-'), workers);
-			if(row.length == 0) {
+			if(row.length === 0) {
 				row = Outside.makeWorkerRow(k, workerCount);
 				
 				var curPrev = null;
@@ -255,7 +255,7 @@ var Outside = {
 						}
 					}
 				});
-				if(curPrev == null && gatherer.length == 0) {
+				if(curPrev == null && gatherer.length === 0) {
 					row.prependTo(workers);
 				} 
 				else if(curPrev == null)
@@ -271,7 +271,7 @@ var Outside = {
 				$('div#' + row.attr('id') + ' > div.row_val > span', workers).text(workerCount);
 			}
 			numGatherers -= workerCount;
-			if(workerCount == 0) {
+			if(workerCount === 0) {
 				$('.dnBtn', row).addClass('disabled');
 				$('.dnManyBtn', row).addClass('disabled');
 			} else {
@@ -280,14 +280,14 @@ var Outside = {
 			}
 		}
 		
-		if(gatherer.length == 0) {
+		if(gatherer.length === 0) {
 			gatherer = Outside.makeWorkerRow('gatherer', numGatherers);
 			gatherer.prependTo(workers);
 		} else {
 			$('div#workers_row_gatherer > div.row_val > span', workers).text(numGatherers);
 		}
 		
-		if(numGatherers == 0) {
+		if(numGatherers === 0) {
 			$('.upBtn', '#workers').addClass('disabled');
 			$('.upManyBtn', '#workers').addClass('disabled');
 		} else {
@@ -363,7 +363,7 @@ var Outside = {
 	updateVillageRow: function(name, num, village) {
 		var id = 'building_row_' + name.replace(' ', '-');
 		var row = $('div#' + id, village);
-		if(row.length == 0 && num > 0) {
+		if(row.length === 0 && num > 0) {
 			row = $('<div>').attr('id', id).addClass('storeRow');
 			$('<div>').addClass('row_key').text(_(name)).appendTo(row);
 			$('<div>').addClass('row_val').text(num).appendTo(row);
@@ -385,7 +385,7 @@ var Outside = {
 			}
 		} else if(num > 0) {
 			$('div#' + row.attr('id') + ' > div.row_val', village).text(num);
-		} else if(num == 0) {
+		} else if(num === 0) {
 			row.remove();
 		}
 	},
@@ -394,7 +394,7 @@ var Outside = {
 		var village = $('div#village');
 		var population = $('div#population');
 		var needsAppend = false;
-		if(village.length == 0) {
+		if(village.length === 0) {
 			needsAppend = true;
 			village = $('<div>').attr('id', 'village').css('opacity', 0);
 			population = $('<div>').attr('id', 'population').appendTo(village);
@@ -419,7 +419,7 @@ var Outside = {
 		population.text(_('pop ') + $SM.get('game.population') + '/' + this.getMaxPopulation());
 		
 		var hasPeeps;
-		if($SM.get('game.buildings["hut"]', true) == 0) {
+		if($SM.get('game.buildings["hut"]', true) === 0) {
 			hasPeeps = false;
 			village.addClass('noHuts');
 		} else {
@@ -504,7 +504,7 @@ var Outside = {
 	updateTrapButton: function() {
 		var btn = $('div#trapsButton');
 		if($SM.get('game.buildings["trap"]', true) > 0) {
-			if(btn.length == 0) {
+			if(btn.length === 0) {
 				new Button.Button({
 					id: 'trapsButton',
 					text: _("check traps"),
@@ -525,7 +525,7 @@ var Outside = {
 	setTitle: function() {
 		var numHuts = $SM.get('game.buildings["hut"]', true);
 		var title;
-		if(numHuts == 0) {
+		if(numHuts === 0) {
 			title = _("A Silent Forest");
 		} else if(numHuts == 1) {
 			title = _("A Lonely Hut");
@@ -606,10 +606,10 @@ var Outside = {
 	handleStateUpdates: function(e){
 		if(e.category == 'stores'){
 			Outside.updateVillage();
-		} else if(e.stateName.indexOf('game.workers') == 0 || e.stateName.indexOf('game.population') == 0){
+		} else if(e.stateName.indexOf('game.workers') === 0 || e.stateName.indexOf('game.population') === 0){
 			Outside.updateVillage();
 			Outside.updateWorkersView();
 			Outside.updateVillageIncome();
-		};
+		}
 	}
 };

--- a/script/path.js
+++ b/script/path.js
@@ -97,14 +97,14 @@ var Path = {
 		if($SM.get('character.perks')) {
 			var perks = $('#perks');
 			var needsAppend = false;
-			if(perks.length == 0) {
+			if(perks.length === 0) {
 				needsAppend = true;
 				perks = $('<div>').attr('id', 'perks');
 			}
 			for(var k in $SM.get('character.perks')) {
 				var id = 'perk_' + k.replace(' ', '-');
 				var r = $('#' + id);
-				if($SM.get('character.perks["'+k+'"]') && r.length == 0) {
+				if($SM.get('character.perks["'+k+'"]') && r.length === 0) {
 					r = $('<div>').attr('id', id).addClass('perkRow').appendTo(perks);
 					$('<div>').addClass('row_key').text(_(k)).appendTo(r);
 					$('<div>').addClass('tooltip bottom right').text(Engine.Perks[k].desc).appendTo(r);
@@ -137,7 +137,7 @@ var Path = {
 		else if($SM.get('stores["l armour"]', true) > 0)
 			armour = _("leather");
 		var aRow = $('#armourRow');
-		if(aRow.length == 0) {
+		if(aRow.length === 0) {
 			aRow = $('<div>').attr('id', 'armourRow').addClass('outfitRow').prependTo(outfit);
 			$('<div>').addClass('row_key').text(_('armour')).appendTo(aRow);
 			$('<div>').addClass('row_val').text(armour).appendTo(aRow);
@@ -148,7 +148,7 @@ var Path = {
 		
 		// Add the water row
 		var wRow = $('#waterRow');
-		if(wRow.length == 0) {
+		if(wRow.length === 0) {
 			wRow = $('<div>').attr('id', 'waterRow').addClass('outfitRow').insertAfter(aRow);
 			$('<div>').addClass('row_key').text(_('water')).appendTo(wRow);
 			$('<div>').addClass('row_val').text(World.getMaxWater()).appendTo(wRow);
@@ -183,13 +183,13 @@ var Path = {
 			var row = $('div#outfit_row_' + k.replace(' ', '-'), outfit);
 			if((store.type == 'tool' || store.type == 'weapon') && have > 0) {
 				total += num * Path.getWeight(k);
-				if(row.length == 0) {
+				if(row.length === 0) {
 					row = Path.createOutfittingRow(k, num, store.name);
 					
 					var curPrev = null;
 					outfit.children().each(function(i) {
 						var child = $(this);
-						if(child.attr('id').indexOf('outfit_row_') == 0) {
+						if(child.attr('id').indexOf('outfit_row_') === 0) {
 							var cName = child.attr('id').substring(11).replace('-', ' ');
 							if(cName < k && (curPrev == null || cName > curPrev)) {
 								curPrev = cName;
@@ -207,7 +207,7 @@ var Path = {
 					$('div#' + row.attr('id') + ' > div.row_val > span', outfit).text(num);
 					$('div#' + row.attr('id') + ' .tooltip .numAvailable', outfit).text(numAvailable - num);
 				}
-				if(num == 0) {
+				if(num === 0) {
 					$('.dnBtn', row).addClass('disabled');
 					$('.dnManyBtn', row).addClass('disabled');
 				} else {
@@ -221,7 +221,7 @@ var Path = {
 					$('.upBtn', row).removeClass('disabled');
 					$('.upManyBtn', row).removeClass('disabled');
 				}
-			} else if(have == 0 && row.length > 0) {
+			} else if(have === 0 && row.length > 0) {
 				row.remove();
 			}
 		}
@@ -269,7 +269,7 @@ var Path = {
 			var maxExtraByStore  = $SM.get('stores["'+supply+'"]', true) - cur;
 			var maxExtraByBtn    = btn.data;
 			Path.outfit[supply] = cur + Math.min(maxExtraByBtn, Math.min(maxExtraByWeight, maxExtraByStore));
-			$SM.set('outfit['+supply+']', Path.outfit[supply])
+			$SM.set('outfit['+supply+']', Path.outfit[supply]);
 			Path.updateOutfitting();
 		}
 	},
@@ -281,7 +281,7 @@ var Path = {
 		cur = typeof cur == 'number' ? cur : 0;
 		if(cur > 0) {
 			Path.outfit[supply] = Math.max(0, cur - btn.data);
-			$SM.set('outfit['+supply+']', Path.outfit[supply])
+			$SM.set('outfit['+supply+']', Path.outfit[supply]);
 			Path.updateOutfitting();
 		}
 	},
@@ -310,8 +310,8 @@ var Path = {
 	},
 	
 	handleStateUpdates: function(e){
-		if(e.category == 'character' && e.stateName.indexOf('character.perks') == 0 && Engine.activeModule == Path){
+		if(e.category == 'character' && e.stateName.indexOf('character.perks') === 0 && Engine.activeModule == Path){
 			Path.updatePerks();
-		};
+		}
 	}
 };

--- a/script/room.js
+++ b/script/room.js
@@ -720,7 +720,7 @@ var Room = {
 	
 	updateBuilderState: function() {
 		var lBuilder = $SM.get('game.builder.level');
-		if(lBuilder == 0) {
+		if(lBuilder === 0) {
 			Notifications.notify(Room, _("a ragged stranger stumbles through the door and collapses in the corner"));
 			lBuilder = $SM.setget('game.builder.level', 1);
 			setTimeout(Room.unlockForest, Room._NEED_WOOD_DELAY);
@@ -750,13 +750,13 @@ var Room = {
 		var stores = $('div#stores');
 		var weapons = $('div#weapons');
 		var needsAppend = false, wNeedsAppend = false, newRow = false;
-		if(stores.length == 0) {
+		if(stores.length === 0) {
 			stores = $('<div>').attr({
 				id: 'stores'
 			}).css('opacity', 0);
 			needsAppend = true;
 		}
-		if(weapons.length == 0) {
+		if(weapons.length === 0) {
 			weapons = $('<div>').attr({
 				id: 'weapons'
 			}).css('opacity', 0);
@@ -803,7 +803,7 @@ var Room = {
 				$SM.startThieves();
 			}
 			
-			if(row.length == 0 && num > 0) {
+			if(row.length === 0 && num > 0) {
 				row = $('<div>').attr('id', id).addClass('storeRow');
 				$('<div>').addClass('row_key').text(_(k)).appendTo(row);
 				$('<div>').addClass('row_val').text(Math.floor(num)).appendTo(row);
@@ -848,7 +848,7 @@ var Room = {
 	
 	updateIncomeView: function() {
 		var stores = $('div#stores');
-		if(stores.length == 0 || typeof $SM.get('income') == 'undefined') return;
+		if(stores.length === 0 || typeof $SM.get('income') == 'undefined') return;
 		$('div.storeRow', stores).each(function(index, el) {
 			el = $(el);
 			$('div.tooltip', el).remove();
@@ -857,7 +857,7 @@ var Room = {
 			for(var incomeSource in $SM.get('income')) {
 				var income = $SM.get('income["'+incomeSource+'"]');
 				for(var store in income.stores) {
-					if(store == storeName && income.stores[store] != 0) {
+					if(store == storeName && income.stores[store] !== 0) {
 						$('<div>').addClass('row_key').text(_(incomeSource)).appendTo(tt);
 						$('<div>')
 							.addClass('row_val')
@@ -967,7 +967,7 @@ var Room = {
 		}
 		if($SM.get('game.builder.level') < 4) return false;
 		var craftable = Room.Craftables[thing];
-		if(Room.needsWorkshop(craftable.type) && $SM.get('game.buildings["'+'workshop'+'"]', true) == 0) return false;
+		if(Room.needsWorkshop(craftable.type) && $SM.get('game.buildings["'+'workshop'+'"]', true) === 0) return false;
 		var cost = craftable.cost();
 		
 		//show button if one has already been built
@@ -1008,21 +1008,21 @@ var Room = {
 	updateBuildButtons: function() {
 		var buildSection = $('#buildBtns');
 		var needsAppend = false;
-		if(buildSection.length == 0) {
+		if(buildSection.length === 0) {
 			buildSection = $('<div>').attr('id', 'buildBtns').css('opacity', 0);
 			needsAppend = true;
 		}
 		
 		var craftSection = $('#craftBtns');
 		var cNeedsAppend = false;
-		if(craftSection.length == 0 && $SM.get('game.buildings["workshop"]', true) > 0) {
+		if(craftSection.length === 0 && $SM.get('game.buildings["workshop"]', true) > 0) {
 			craftSection = $('<div>').attr('id', 'craftBtns').css('opacity', 0);
 			cNeedsAppend = true;
 		}
 		
 		var buySection = $('#buyBtns');
 		var bNeedsAppend = false;
-		if(buySection.length == 0 && $SM.get('game.buildings["trading post"]', true) > 0) {
+		if(buySection.length === 0 && $SM.get('game.buildings["trading post"]', true) > 0) {
 			buySection = $('<div>').attr('id', 'buyBtns').css('opacity', 0);
 			bNeedsAppend = true;
 		}
@@ -1113,7 +1113,7 @@ var Room = {
 		} else if(e.category == 'income'){
 			Room.updateStoresView();
 			Room.updateIncomeView();
-		} else if(e.stateName.indexOf('game.buildings') == 0){
+		} else if(e.stateName.indexOf('game.buildings') === 0){
 			Room.updateBuildButtons();
 		}
 	}

--- a/script/room.js
+++ b/script/room.js
@@ -476,8 +476,8 @@ var Room = {
 		
 		// If this is the first time playing, the fire is dead and it's freezing. 
 		// Otherwise grab past save state temp and fire level.
-		$SM.set('game.temperature', $SM.get('game.temperature.value')==undefined?this.TempEnum.Freezing:$SM.get('game.temperature'));
-		$SM.set('game.fire', $SM.get('game.fire.value')==undefined?this.FireEnum.Dead:$SM.get('game.fire'));
+		$SM.set('game.temperature', $SM.get('game.temperature.value')===undefined?this.TempEnum.Freezing:$SM.get('game.temperature'));
+		$SM.set('game.fire', $SM.get('game.fire.value')===undefined?this.FireEnum.Dead:$SM.get('game.fire'));
 		
 		// Create the room tab
 		this.tab = Header.addLocation(_("A Dark Room"), "room", Room);

--- a/script/space.js
+++ b/script/space.js
@@ -136,7 +136,7 @@ var Space = {
 						t.remove();
 						Space.hull--;
 						Space.updateHull();
-						if(Space.hull == 0) {
+						if(Space.hull === 0) {
 							Space.crash();
 						}
 					}
@@ -190,7 +190,7 @@ var Space = {
 			dx += Space.getSpeed();
 		}
 		
-		if(dx != 0 && dy != 0) {
+		if(dx !== 0 && dy !== 0) {
 			dx = dx / Math.sqrt(2);
 			dy = dy / Math.sqrt(2);
 		}
@@ -226,13 +226,15 @@ var Space = {
 	},
 	
 	startAscent: function() {
+		var body_color;
+		var to_color;
 		if (Engine.isLightsOff()) {
-			var body_color = '#272823';
-			var to_color = '#EEEEEE';
+			body_color = '#272823';
+			to_color = '#EEEEEE';
 		}
 		else {
-			var body_color = '#FFFFFF';
-			var to_color = '#000000';
+			body_color = '#FFFFFF';
+			to_color = '#000000';
 		}
 
 		$('body').addClass('noMask').css({backgroundColor: body_color}).animate({
@@ -251,7 +253,7 @@ var Space = {
 		Space.drawStars();
 		Space._timer = setInterval(function() {
 			Space.altitude += 1;
-			if(Space.altitude % 10 == 0) {
+			if(Space.altitude % 10 === 0) {
 				Space.setTitle();
 			}
 			if(Space.altitude > 60) {
@@ -324,10 +326,11 @@ var Space = {
 		clearInterval(Space._timer);
 		clearInterval(Space._shipTimer);
 		clearTimeout(Space._panelTimeout);
+		var body_color;
 		if (Engine.isLightsOff())
-			var body_color = '#272823';
+			body_color = '#272823';
 		else
-			var body_color = '#FFFFFF';
+			body_color = '#FFFFFF';
 		// Craaaaash!
 		$('body').removeClass('noMask').stop().animate({
 			backgroundColor: body_color
@@ -392,10 +395,11 @@ var Space = {
 					$('#header').empty();
 					setTimeout(function() {
 						$('body').stop();
+						var container_color;
 						if (Engine.isLightsOff())
-							var container_color = '#EEE';
+							container_color = '#EEE';
 						else
-							var container_color = '#000';
+							container_color = '#000';
 						$('#starsContainer').animate({
 							opacity: 0,
 							'background-color': container_color

--- a/script/state_manager.js
+++ b/script/state_manager.js
@@ -100,7 +100,7 @@ var StateManager = {
 		$SM.buildPath(parentName);
 		
 		//make sure the state exists to avoid errors,
-		if($SM.get(parentName) == undefined) $SM.set(parentName, {}, true);
+		if($SM.get(parentName) === undefined) $SM.set(parentName, {}, true);
 		
 		for(var k in list){
 			$SM.set(parentName+'["'+k+'"]', list[k], true);
@@ -140,7 +140,7 @@ var StateManager = {
 		var err = 0;
 		
 		//make sure the parent exists to avoid errors
-		if($SM.get(parentName) == undefined) $SM.set(parentName, {}, true);
+		if($SM.get(parentName) === undefined) $SM.set(parentName, {}, true);
 		
 		for(var k in list){
 			if($SM.add(parentName+'["'+k+'"]', list[k], true)) err++;
@@ -200,7 +200,7 @@ var StateManager = {
 	
 	fireUpdate: function(stateName, save){
 		var category = $SM.getCategory(stateName);
-		if(stateName == undefined) stateName = category = 'all'; //best if this doesn't happen as it will trigger more stuff
+		if(stateName === undefined) stateName = category = 'all'; //best if this doesn't happen as it will trigger more stuff
 		$.Dispatch('stateUpdate').publish({'category': category, 'stateName':stateName});
 		if(save) Engine.saveGame();
 	},

--- a/script/state_manager.js
+++ b/script/state_manager.js
@@ -200,7 +200,7 @@ var StateManager = {
 	
 	fireUpdate: function(stateName, save){
 		var category = $SM.getCategory(stateName);
-		if(stateName === undefined) stateName = category = 'all'; //best if this doesn't happen as it will trigger more stuff
+		if(stateName == undefined) stateName = category = 'all'; //best if this doesn't happen as it will trigger more stuff
 		$.Dispatch('stateUpdate').publish({'category': category, 'stateName':stateName});
 		if(save) Engine.saveGame();
 	},

--- a/script/state_manager.js
+++ b/script/state_manager.js
@@ -41,7 +41,7 @@ var StateManager = {
 		
 		for(var which in cats) {
 			if(!$SM.get(cats[which])) $SM.set(cats[which], {}); 
-		};
+		}
 		
 		//subscribe to stateUpdates
 		$.Dispatch('stateUpdate').subscribe($SM.handleStateUpdates);
@@ -56,7 +56,7 @@ var StateManager = {
 				words.splice(i, 1);
 				i--;
 			}
-		};
+		}
 		var obj = State;
 		var w = null;
 		for(var i=0, len=words.length-1;i<len;i++){
@@ -84,7 +84,7 @@ var StateManager = {
 		}
 		
 		//stores values can not be negative
-		if(stateName.indexOf('stores') == 0 && $SM.get(stateName, true) < 0) {
+		if(stateName.indexOf('stores') === 0 && $SM.get(stateName, true) < 0) {
 			eval('('+fullPath+') = 0');
 			Engine.log('WARNING: state:' + stateName + ' can not be a negative value. Set to 0 instead.');
 		}
@@ -188,7 +188,7 @@ var StateManager = {
 		if(!noEvent){
 			Engine.saveGame();
 			$SM.fireUpdate(stateName);
-		};
+		}
 	},
 	
 	//creates full reference from input
@@ -231,7 +231,7 @@ var StateManager = {
 			$SM.remove('income.hunter', true);
 			Engine.log('upgraded save to v1.1');
 			version = 1.1;
-		};
+		}
 		if(version == 1.1) {
 			//v1.2 added the Swamp to the map, so add it to already generated maps
 			if($SM.get('world')) {
@@ -239,7 +239,7 @@ var StateManager = {
 			}
 			Engine.log('upgraded save to v1.2');
 			version = 1.2;
-		};
+		}
 		if(version == 1.2) {
 			//StateManager added, so move data to new locations
 			$SM.remove('room.fire');
@@ -249,7 +249,7 @@ var StateManager = {
 				$SM.set('features.location.room', true);
 				$SM.set('game.builder.level', $SM.get('room.builder'));
 				$SM.remove('room');
-			};
+			}
 			if($SM.get('outside')){
 				$SM.set('features.location.outside', true);
 				$SM.set('game.population', $SM.get('outside.population'));
@@ -257,7 +257,7 @@ var StateManager = {
 				$SM.set('game.workers', $SM.get('outside.workers'));
 				$SM.set('game.outside.seenForest', $SM.get('outside.seenForest'));
 				$SM.remove('outside');
-			};
+			}
 			if($SM.get('world')){
 				$SM.set('features.location.world', true);
 				$SM.set('game.world.map', $SM.get('world.map'));
@@ -267,7 +267,7 @@ var StateManager = {
 				$SM.remove('world');
 				$SM.remove('starved');
 				$SM.remove('dehydrated');
-			};
+			}
 			if($SM.get('ship')){
 				$SM.set('features.location.spaceShip', true);
 				$SM.set('game.spaceShip.hull', $SM.get('ship.hull', true));
@@ -275,29 +275,29 @@ var StateManager = {
 				$SM.set('game.spaceShip.seenWarning', $SM.get('ship.seenWarning'));
 				$SM.set('game.spaceShip.seenShip', $SM.get('ship.seenShip'));
 				$SM.remove('ship');
-			};
+			}
 			if($SM.get('punches')){
 				$SM.set('character.punches', $SM.get('punches'));
 				$SM.remove('punches');
-			};
+			}
 			if($SM.get('perks')){
 				$SM.set('character.perks', $SM.get('perks'));
 				$SM.remove('perks');
-			};
+			}
 			if($SM.get('thieves')){
 				$SM.set('game.thieves', $SM.get('thieves'));
 				$SM.remove('thieves');
-			};
+			}
 			if($SM.get('stolen')){
 				$SM.set('game.stolen', $SM.get('stolen'));
 				$SM.remove('stolen');
-			};
+			}
 			if($SM.get('cityCleared')){
 				$SM.set('character.cityCleared', $SM.get('cityCleared'));
 				$SM.remove('cityCleared');
-			};
+			}
 			$SM.set('version', 1.3);
-		};
+		}
 	},
 	
 	/******************************************************************
@@ -356,7 +356,7 @@ var StateManager = {
 					        }
 					    }
 					}
-					
+
 					if(ok){
 						$SM.addM('stores', income.stores, true);
 					}
@@ -369,7 +369,7 @@ var StateManager = {
 		}
 		if(changed){
 			$SM.fireUpdate('income', true);
-		};
+		}
 		Engine._incomeTimeout = setTimeout($SM.collectIncome, 1000);
 	},
 	
@@ -384,7 +384,7 @@ var StateManager = {
 			} else {
 				$SM.add('game.stolen["'+k+'"]', stores[k] * -1);
 			}
-		};
+		}
 	},
 	
 	startThieves: function() {

--- a/script/state_manager.js
+++ b/script/state_manager.js
@@ -52,7 +52,7 @@ var StateManager = {
 		var words = stateName.split(/[.\[\]'"]+/);
 		//for some reason there are sometimes empty strings
 		for (var i = 0; i < words.length; i++) {
-			if (words[i] == '') {
+			if (words[i] === '') {
 				words.splice(i, 1);
 				i--;
 			}

--- a/script/world.js
+++ b/script/world.js
@@ -410,11 +410,11 @@ var World = {
 	checkDanger: function() {
 		World.danger = typeof World.danger == 'undefined' ? false: World.danger;
 		if(!World.danger) {
-			if(!$SM.get('stores["i armour"]', true) > 0 && World.getDistance() >= 8) {
+			if($SM.get('stores["i armour"]', true) === 0 && World.getDistance() >= 8) {
 				World.danger = true;
 				return true;
 			} 
-			if(!$SM.get('stores["s armour"]', true) > 0 && World.getDistance() >= 18) {
+			if($SM.get('stores["s armour"]', true) === 0 && World.getDistance() >= 18) {
 				World.danger = true;
 				return true;
 			}

--- a/script/world.js
+++ b/script/world.js
@@ -905,7 +905,7 @@ var World = {
 		x = typeof x == 'number' ? x : World.curPos[0];
 		y = typeof y == 'number' ? y : World.curPos[1];
 		var used = World.usedOutposts[x + ',' + y];
-		return typeof used != 'undefined' && used == true;
+		return typeof used != 'undefined' && used === true;
 	},
 	
 	useOutpost: function() {

--- a/script/world.js
+++ b/script/world.js
@@ -243,7 +243,7 @@ var World = {
 		
 		// Add water
 		var water = $('div#supply_water');
-		if(World.water > 0 && water.length == 0) {
+		if(World.water > 0 && water.length === 0) {
 			water = World.createItemDiv('water', World.water);
 			water.prependTo(supplies);
 		} else if(World.water > 0) {
@@ -257,7 +257,7 @@ var World = {
 			var item = $('div#supply_' + k.replace(' ', '-'), supplies);
 			var num = Path.outfit[k];
 			total += num * Path.getWeight(k);
-			if(num > 0 && item.length == 0) {
+			if(num > 0 && item.length === 0) {
 				item = World.createItemDiv(k, num);
 				if(k == 'cured meat' && World.water > 0) {
 					item.insertAfter(water);
@@ -441,7 +441,7 @@ var World = {
 			World.foodMove = 0;
 			var num = Path.outfit['cured meat'];
 			num--;
-			if(num == 0) {
+			if(num === 0) {
 				Notifications.notify(World, _('the meat has run out'));
 			} else if(num < 0) {
 				// Starvation! Hooray!
@@ -471,7 +471,7 @@ var World = {
 			World.waterMove = 0;
 			var water = World.water;
 			water--;
-			if(water == 0) {
+			if(water === 0) {
 				Notifications.notify(World, _('there is no more water'));
 			} else if(water < 0) {
 				water = 0;
@@ -754,7 +754,7 @@ var World = {
 	
 	drawMap: function() {
 		var map = $('#map');
-		if(map.length == 0) {
+		if(map.length === 0) {
 			map = new $('<div>').attr('id', 'map').appendTo('#worldOuter');
 			// register click handler
 			map.click(World.click);
@@ -831,15 +831,15 @@ var World = {
 	goHome: function() {
 		// Home safe! Commit the changes.
 		$SM.setM('game.world', World.state);
-		if(World.state.sulphurmine && $SM.get('game.buildings["sulphur mine"]', true) == 0) {
+		if(World.state.sulphurmine && $SM.get('game.buildings["sulphur mine"]', true) === 0) {
 			$SM.add('game.buildings["sulphur mine"]', 1);
 			Engine.event('progress', 'sulphur mine');
 		}
-		if(World.state.ironmine && $SM.get('game.buildings["iron mine"]', true) == 0) {
+		if(World.state.ironmine && $SM.get('game.buildings["iron mine"]', true) === 0) {
 			$SM.add('game.buildings["iron mine"]', 1);
 			Engine.event('progress', 'iron mine');
 		}
-		if(World.state.coalmine && $SM.get('game.buildings["coal mine"]', true) == 0) {
+		if(World.state.coalmine && $SM.get('game.buildings["coal mine"]', true) === 0) {
 			$SM.add('game.buildings["coal mine"]', 1);
 			Engine.event('progress', 'coal mine');
 		}
@@ -868,8 +868,8 @@ var World = {
 	},
 	
 	leaveItAtHome: function(thing) {
-		 return thing != 'cured meat' && thing != 'bullets' && thing != 'energy cell'  && thing != 'charm' && thing != 'medicine'
-			 && typeof World.Weapons[thing] == 'undefined' && typeof Room.Craftables[thing] == 'undefined';
+		 return thing != 'cured meat' && thing != 'bullets' && thing != 'energy cell'  && thing != 'charm' && thing != 'medicine' &&
+		 typeof World.Weapons[thing] == 'undefined' && typeof Room.Craftables[thing] == 'undefined';
 	},
 	
 	getMaxHealth: function() {


### PR DESCRIPTION
This fixes many (but not all) JS Hint warnings. Specifically, only low risk changes were made. i.e. small changes which should be safe and don't change semantics significantly.

* Added in missing semicolons (and removed redundant ones).
* Changed ```== 0``` and ```!= 0``` to triple equals.
* Renamed some of the variables hiding a parameter with the same name.
* Used array literal ```[]``` instead of ```new Array()```
* Removed one instance of a statement which did nothing (```Engine.turnLightsOff;``` didn't actually call the function, and it seems to work fine without it)
* Removed null definitions which were later defined as something (```activeEvent``` and ```eventPanel``` in ```script/event.js```).
* Fixed some whitespace that Sublime Text wanted to modify on every save in ```stage_manager.js``` (was spaces and not tabs). Sorry, it's unrelated to this!
* Moved some variable definitions to outside of if statements (```space.js```).
* Fixed (moved) line break position in the middle of an if statement.
* Fixed comparisons to ```''``` and ```true``` to use triple equals.
* Fixed all checks for ```undefined``` returned from ```$SM.get``` to use ```===``` or  ```!==``` because we know it will return a value, 0 or undefined.
* Fixed "Confusing use of '!'" warnings. Since ```$SM.get``` returns a zero if null, I replaced with ```=== 0```.

I purposefully didn't change any of the ```== null```s or ```== undefined```s (except checks to the return value of ```$SM.get```) as these I expect would require much more testing (and it's open to interpretation about whether or not they are good/bad).

Down to 24 errors from JSHint with this .jshintrc (not committed, as a linter hasn't been chosen in #188 yet).

```
{
  "eqnull": true,
  "sub": true,
  "multistr": true
}
```
Remaining warnings below (will update this description if some issues are fixed).

Notes to fix remaining issues:

*  ```Don't make functions within a loop.``` Fix these by extracting functions to outside the loop and calling from within the loop. Functions defined inside a loop get _redeclared_ on each iteration.
* ```'k' is already defined.``` These loops could be refactored to a function, or just ```var k``` at the top of the function.
* ```Variables should not be deleted.``` Could set it to null instead.

```
script/events.js: line 272, col 27, 'k' is already defined.

script/localization.js: line 68, col 20, Variables should not be deleted.

script/outside.js: line 257, col 18, Don't make functions within a loop.
script/outside.js: line 589, col 19, 'i' is already defined.

script/path.js: line 198, col 22, Don't make functions within a loop.

script/room.js: line 818, col 18, Don't make functions within a loop.
script/room.js: line 1050, col 27, 'k' is already defined.
script/room.js: line 1065, col 19, 'k' is already defined.
script/room.js: line 1067, col 21, 'max' is already defined.
script/room.js: line 1080, col 33, 'costTooltip' is already defined.
script/room.js: line 1082, col 26, 'cost' is already defined.
script/room.js: line 1083, col 27, 'k' is already defined.

script/space.js: line 378, col 19, 'k' is already defined.

script/state_manager.js: line 62, col 18, 'i' is already defined.
script/state_manager.js: line 80, col 13, eval can be harmful.
script/state_manager.js: line 88, col 13, eval can be harmful.
script/state_manager.js: line 163, col 13, eval can be harmful.
script/state_manager.js: line 177, col 16, eval can be harmful.
script/state_manager.js: line 183, col 13, eval can be harmful.
script/state_manager.js: line 203, col 22, Use '===' to compare with 'undefined'.

script/world.js: line 652, col 23, 'i' is already defined.
script/world.js: line 721, col 25, 'cur' is already defined.
script/world.js: line 729, col 19, 't' is already defined.
script/world.js: line 740, col 19, 'i' is already defined.

24 errors
```