### PR TITLE
Limit Fire event to only Outside module

### DIFF
--- a/script/events/outside.js
+++ b/script/events/outside.js
@@ -66,7 +66,7 @@ Events.Outside = [
 	{
 		title: _('Fire'),
 		isAvailable: function() {
-			return $SM.get('game.buildings["hut"]', true) > 0 && $SM.get('game.population', true) > 5;
+			return Engine.activeModule == Outside && $SM.get('game.buildings["hut"]', true) > 0 && $SM.get('game.population', true) > 5;
 		},
 		scenes: {
 			'start': {


### PR DESCRIPTION
Realized while headed to bed that this wasn't actually being limited by active module, just by quantity of hut / population. This PR limits the Fire event to only firing if the Outside module is active.